### PR TITLE
Fix reconnecting to servers

### DIFF
--- a/src/main/java/com/zachsthings/netevents/Forwarder.java
+++ b/src/main/java/com/zachsthings/netevents/Forwarder.java
@@ -45,16 +45,17 @@ public class Forwarder implements Closeable {
     class ConnectionCloseListener implements Runnable {
         @Override
         public void run() {
-            conn.set(null);
             if (Forwarder.this.reconnectAddress != null) {
                 plugin.getReconnectTask().schedule(Forwarder.this);
             } else {
                 plugin.removeForwarder(Forwarder.this);
             }
+            conn.set(null);
         }
     }
 
     public void connect(SocketAddress addr) throws IOException {
+        remoteServerUUID.set(null);
         reconnectAddress = addr;
         final SocketChannel sock;
         try {


### PR DESCRIPTION
**Moving `conn.set(null);`**
NetEvents didn't remove any Forwarders from `NetEvents.forwarders`, because`NetEventsPlugin.removeForwarder(Forwarder f)` has always been called with a `null`-argument.

**Adding `remoteServerUUID.set(null);`**
After reconnecting to a server, NetEvents throws a `IllegalStateException` in `Forwarder.java:95` (commited version: `Forwarder.java:96`).
